### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to response back.
 5. Run `bundle install`
 6. Edit the _config.yml on root directory. Change `url` property to to 
 `http://127.0.0.1:4000` since you are going to run on localhost.
-7. Run the jekyll server by having: `jekyll serve --baseurl ''` or `rake preview`   
+7. Run the jekyll server by having: `bundle exec jekyll serve --baseurl ''` or `rake preview`   
 
 Try to locate your browser at [http://localhost:4000](http://localhost:4000).
 


### PR DESCRIPTION
Trying to serve jekyll without `bundle exec` throws an error (https://github.com/jekyll/jekyll/issues/3084)
