### PR TITLE
Show share link separators properly

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -20,14 +20,14 @@
             href="https://twitter.com/{{ site.theme.social.twitter }}" 
             class="twitter" target="_blank">Twitter</a>
     {% endif %}
-    /
     {% if site.theme.social.facebook %}
+        /
         <a title="{{ site.theme.social.facebook }} on Facebook" 
             href="https://facebook.com/{{ site.theme.social.facebook }}" 
             class="facebook" target="_blank">Facebook</a>
     {% endif %} 
-    /
     {% if site.theme.social.gplus %}
+        /
         <a title="{{ site.theme.social.gplus }} on Google Plus" 
             href="https://plus.google.com/{{ site.theme.social.gplus }}" 
             class="google" target="_blank">Google</a>


### PR DESCRIPTION
Since I don't have Google Plus, I noticed it was rendering an extra `/` separator. Here's a fix.
