### PR TITLE
Use default jekyll lists positioning

### DIFF
--- a/assets/css/_sass/base/_type.scss
+++ b/assets/css/_sass/base/_type.scss
@@ -173,7 +173,7 @@ ol {
 }
 
 ul,ol {
-  list-style-position: inside;
+  margin-left: 30px;
 }
 ul {
   list-style-type: square;


### PR DESCRIPTION
I wasn't able to have multiple paragraphs in ordered and unordered lists.

**Before:**
![screen shot 2015-03-15 at 11 19 22 pm](https://cloud.githubusercontent.com/assets/1196663/6659725/3fdf8742-cb6a-11e4-97fa-54ccd71494f1.png)

**After:**
![screen shot 2015-03-15 at 11 19 35 pm](https://cloud.githubusercontent.com/assets/1196663/6659726/41a4ff4e-cb6a-11e4-86ed-df7d29ee871b.png)
