### PR TITLE
remove duplicate title tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,8 +4,6 @@
 <!--[if IE 8]>    <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->  
   <head>
-    <title></title>
-
     <meta charset="utf-8">
     {% comment %}
     <!-- Enable responsiveness on mobile devices-->


### PR DESCRIPTION
The blank `title` tag prevents the title to show on browser.
